### PR TITLE
Set SSL Protocol rather than defaulting to deprecated one.

### DIFF
--- a/pypki3/config.py
+++ b/pypki3/config.py
@@ -301,7 +301,7 @@ class Loader:
         with ContextManagerClass(password) as key_cert_paths:
             key_path = key_cert_paths[0]
             cert_path = key_cert_paths[1]
-            context = ssl.SSLContext()
+            context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
             context.load_cert_chain(cert_path, key_path)
             context.verify_mode = ssl.CERT_REQUIRED
             context.load_verify_locations(cafile=self.ca_path())


### PR DESCRIPTION
This PR adds in a default SSL Protocol (`ssl.PROTOCOL_TLS_CLIENT`), rather than defaulting to the now-deprecated `ssl.PROTOCOL_TLS`).