### PR TITLE
Updates to separate_pem() to add functionality to identify/validate/return key & cert(s) in PEM regardless of order

### DIFF
--- a/pypki3/config.py
+++ b/pypki3/config.py
@@ -205,9 +205,11 @@ def separate_pem(pem_data: bytes) -> Tuple[bytes, List[bytes]]:
 
     if not key and not certs:
         raise Pypki3Exception('PEM missing key and certificate(s)')
-    elif key and not certs:
+
+    if key and not certs:
         raise Pypki3Exception('PEM contains key but is missing certificate(s)')
-    elif certs and not key:
+
+    if certs and not key:
         raise Pypki3Exception('PEM contains certificate(s) but is missing key')
 
     return key.as_bytes(), [cert.as_bytes() for cert in certs]

--- a/pypki3/config.py
+++ b/pypki3/config.py
@@ -21,7 +21,7 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
 from cryptography import x509
 
-from pem import parse as parse_pem
+from pem import parse as parse_pem, PrivateKey, Certificate
 
 from temppath import TemporaryPath, TemporaryPathContext
 
@@ -193,12 +193,24 @@ def loaded_encoded_pem(key_obj: Any, cert_obj: Any) -> LoadedPKIBytes:
     return LoadedPKIBytes(key_bytes, cert_bytes)
 
 def separate_pem(pem_data: bytes) -> Tuple[bytes, List[bytes]]:
-    certs = parse_pem(pem_data)
+    pem_objs = parse_pem(pem_data)
+    key = None
+    certs = list()
+    
+    for pem_obj in reversed(pem_objs):
+        if isinstance(pem_obj, PrivateKey):
+            key = pem_obj
+        elif isinstance(pem_obj, Certificate):
+            certs.append(pem_obj)
 
-    if len(certs) < 2:
-        raise Pypki3Exception('PEM must contain the key then certificate(s)')
+    if not key and not certs:
+        raise Pypki3Exception('PEM missing key and certificate(s)')
+    elif key and not certs:
+        raise Pypki3Exception('PEM contains key but is missing certificate(s)')
+    elif certs and not key:
+        raise Pypki3Exception('PEM contains certificate(s) but is missing key')
 
-    return certs[0].as_bytes(), [x.as_bytes() for x in certs[1:]]
+    return key.as_bytes(), [cert.as_bytes() for cert in certs]
 
 def find_matching_cert(key_obj: Any, certs_data: List[bytes]) -> Any:
     key_public_num = key_obj.public_key().public_numbers()


### PR DESCRIPTION
Updated `separate_pem()` in `pypki3/config.py` to add functionality to identify/validate/return key & cert(s) in PEM regardless of order.

In the unlikely event there are multiple keys in one PEM file it will use the first key listed in the PEM, which is in-line with the current logic that only ever uses/assigns a single key.

Fixes #8